### PR TITLE
Include Element as part of BoxTree items.

### DIFF
--- a/source/BoxTree.zig
+++ b/source/BoxTree.zig
@@ -180,6 +180,7 @@ pub const Subtree = struct {
         skip: Size,
         type: BlockType,
         stacking_context: ?StackingContextTree.Id,
+        element: Element,
         offset: math.Vector,
         box_offsets: BoxOffsets,
         borders: Borders,
@@ -233,6 +234,7 @@ pub const Subtree = struct {
 pub const InlineFormattingContext = struct {
     id: Id,
     parent_block: BlockRef,
+    element: Element = .null_element,
 
     glyphs: MultiArrayList(struct {
         index: GlyphIndex,
@@ -253,6 +255,7 @@ pub const InlineFormattingContext = struct {
     pub const Id = enum(u16) { _ };
 
     pub const InlineBoxList = MultiArrayList(struct {
+        element: Element,
         skip: Size,
         inline_start: BoxProperties,
         inline_end: BoxProperties,

--- a/source/Layout/BoxTreeManaged.zig
+++ b/source/Layout/BoxTreeManaged.zig
@@ -15,6 +15,20 @@ const Subtree = BoxTree.Subtree;
 ptr: *BoxTree,
 
 pub fn setGeneratedBox(box_tree: BoxTreeManaged, element: Element, generated_box: GeneratedBox) !void {
+    switch (generated_box) {
+        .block_ref => |block_ref| {
+            const subtree = box_tree.ptr.getSubtree(block_ref.subtree);
+            subtree.blocks.items(.element)[block_ref.index] = element;
+        },
+        .inline_box => |inline_box| {
+            const ifc = box_tree.ptr.getIfc(inline_box.ifc_id);
+            ifc.inline_boxes.items(.element)[inline_box.index] = element;
+        },
+        .text => |text| {
+            const ifc = box_tree.ptr.getIfc(text);
+            ifc.element = element;
+        },
+    }
     try box_tree.ptr.element_to_generated_box.putNoClobber(box_tree.ptr.allocator, element, generated_box);
 }
 


### PR DESCRIPTION
I wanted to try building a WYSIWYG editor based around this library, and have been mostly messing with the demo to familiarize myself.

I've noticed, however that currently, there's no way to communicate information about where an element is on-screen. So, for example, if someone were to click on the window, there's no good way to retrieve the element that was clicked, because neither the `BoxTree` nor the `DrawList` have any information about the Element that created the box or drawable.

I figured I'd do this myself, but I'm still not familiar with the codebase. I imagine a `elementAt(width: u32, height: u32)` method, either on the `BoxTree` or `DrawList`, but I'm still not entirely sure how those are meant to be navigated. I'm also not sure if you want some other way to reference the originating `Element` in the `BoxTree`, but this seemed the most obvious way.